### PR TITLE
Time isn't valid, but Logstash::Timestamp is

### DIFF
--- a/lib/logstash/outputs/datadog_metrics.rb
+++ b/lib/logstash/outputs/datadog_metrics.rb
@@ -117,7 +117,7 @@ class LogStash::Outputs::DatadogMetrics < LogStash::Outputs::Base
 
   private
   def to_epoch(t)
-    return t.is_a?(Time) ? t.to_i : Time.parse(t).to_i
+    return t.is_a?(LogStash::Timestamp) ? t.to_i : Time.parse(t).to_i
   end # def to_epoch
 
 end # class LogStash::Outputs::DatadogMetrics

--- a/logstash-output-datadog_metrics.gemspec
+++ b/logstash-output-datadog_metrics.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-datadog_metrics'
-  s.version         = '0.1.4'
+  s.version         = '0.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you send metrics to DataDogHQ based on Logstash events."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
`event.timestamp` is of time `Logstash::Timestamp`. I'm not sure how you could ever get a non-`::Timestamp` as your value in `event.timestamp`, but maybe there's something I don't understand. It definitely fails the `is_a(Time)` though.
