### PR TITLE
Allow passing tags from event to datadog

### DIFF
--- a/lib/logstash/outputs/datadog_metrics.rb
+++ b/lib/logstash/outputs/datadog_metrics.rb
@@ -79,6 +79,8 @@ module LogStash module Outputs class DatadogMetrics < LogStash::Outputs::Base
 
     if @dd_tags
       tagz = @dd_tags.collect {|x| event.sprintf(x) }
+    elsif event["dd_tags"]
+      tagz = event["dd_tags"]
     else
       tagz = event["tags"]
     end


### PR DESCRIPTION
Instead of specifying static tags in the config, we'd like to pass them through the logstream.
