### PR TITLE
Change  config type to  to prevent from leaks in debug logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.0.4
+  - Change `api_key` config type to `password` to prevent leaking in debug logs [#18](https://github.com/logstash-plugins/logstash-output-datadog_metrics/pull/18)
+
+## 3.0.4
   - Docs: Set the default_codec doc attribute.
 
 ## 3.0.3

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -34,7 +34,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-api_key>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-api_key>> |<<password,password>>|Yes
 | <<plugins-{type}s-{plugin}-dd_tags>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-device>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
@@ -54,7 +54,7 @@ output plugins.
 ===== `api_key` 
 
   * This is a required setting.
-  * Value type is <<string,string>>
+  * Value type is <<password,password>>
   * There is no default value for this setting.
 
 Your DatadogHQ API key. https://app.datadoghq.com/account/settings#api

--- a/lib/logstash/outputs/datadog_metrics.rb
+++ b/lib/logstash/outputs/datadog_metrics.rb
@@ -17,7 +17,7 @@ module LogStash module Outputs class DatadogMetrics < LogStash::Outputs::Base
   config_name "datadog_metrics"
 
   # Your DatadogHQ API key. https://app.datadoghq.com/account/settings#api
-  config :api_key, :validate => :string, :required => true
+  config :api_key, :validate => :password, :required => true
 
   # The name of the time series.
   config :metric_name, :validate => :string, :default => "%{metric_name}"
@@ -92,7 +92,7 @@ module LogStash module Outputs class DatadogMetrics < LogStash::Outputs::Base
     dd_series = Hash.new
     dd_series['series'] = Array(events).flatten
 
-    request = Net::HTTP::Post.new("#{@uri.path}?api_key=#{@api_key}")
+    request = Net::HTTP::Post.new("#{@uri.path}?api_key=#{@api_key.value}")
 
     begin
       request.body = series_to_json(dd_series)

--- a/logstash-output-datadog_metrics.gemspec
+++ b/logstash-output-datadog_metrics.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-datadog_metrics'
-  s.version         = '3.0.4'
+  s.version         = '3.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends metrics to DataDogHQ based on Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/datadog_metrics_spec.rb
+++ b/spec/outputs/datadog_metrics_spec.rb
@@ -83,4 +83,10 @@ describe LogStash::Outputs::DatadogMetrics do
     end
   end
 
+  describe "debugging `api_key`" do
+    it "should not show origin value" do
+      expect(subject.logger).to receive(:debug).with('<password>')
+      subject.logger.send(:debug, subject.api_key.to_s)
+    end
+  end
 end


### PR DESCRIPTION
When running Logstash with `--config.debug` mode, `api_key` value can be seen in the debug logs. This change prevents leaking `api_key` value in the debug logs.

- Closes #17 
