### PR TITLE
Actual changelog version up. :facepalm:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.4
+## 3.0.5
   - Change `api_key` config type to `password` to prevent leaking in debug logs [#18](https://github.com/logstash-plugins/logstash-output-datadog_metrics/pull/18)
 
 ## 3.0.4


### PR DESCRIPTION
https://github.com/logstash-plugins/logstash-output-datadog_metrics/pull/18 PR didn't change the Changelog version, sorry.
